### PR TITLE
Make viewport-enter state always available in the class, even if the …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wide/viewport",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Handle intersection between elements and the viewport.",
   "license": "MIT",
   "author": "Aymeric Assier (https://github.com/myeti)",

--- a/src/index.js
+++ b/src/index.js
@@ -93,7 +93,7 @@ function setActive(el, name) {
   el.removeEventListener('animationend', e => setActive(el, name), { once: true })
   el.removeEventListener('transitionend', e => setActive(el, name), { once: true })
 
-  el.classList.remove(CLASSLIST.enter(name))
+  el.classList.add(CLASSLIST.enter(name))
   el.classList.add(CLASSLIST.active(name))
   el.classList.remove(CLASSLIST.leave(name))
 }


### PR DESCRIPTION
Fix: Make viewport-enter state always available in the class, even if the element is active